### PR TITLE
WIP: remove old results on new run

### DIFF
--- a/src/vivarium_csu_ltbi/data/cli.py
+++ b/src/vivarium_csu_ltbi/data/cli.py
@@ -64,7 +64,7 @@ def get_ltbi_incidence_parallel(country):
                                   "-N get_ltbi_incidence")
         jids = s.runBulkJobs(jt, 1, 1000, 1)
         parent_jid = jids[0].split('.')[0]
-        logger.info(f"Submitted array job ({parent_jid}) for calculating LTBI incidence.")
+        logger.info(f"Submitted array job ({parent_jid}) for calculating LTBI incidence in {country}.")
         jt.delete()
 
         jt = s.createJobTemplate()
@@ -74,5 +74,5 @@ def get_ltbi_incidence_parallel(country):
         jt.nativeSpecification = ("-V -b y -P proj_cost_effect -q all.q -l fmem=4G -l fthread=1 -l h_rt=3:00:00 "
                                   f"-N collect_ltbi_incidence -hold_jid {parent_jid}")
         jid = s.runJob(jt)
-        logger.info(f"Submitted hold job ({jid}) for aggregating LTBI incidence.")
+        logger.info(f"Submitted hold job ({jid}) for aggregating LTBI incidence in {country}.")
         jt.delete()

--- a/src/vivarium_csu_ltbi/data/cli.py
+++ b/src/vivarium_csu_ltbi/data/cli.py
@@ -36,7 +36,7 @@ def get_ltbi_incidence_input_data():
         logger.info("Pulling data.")
         p_ltbi, f_ltbi, csmr_all = load_data(country)
 
-        logger.info(f"Writing data to {art}.")
+        logger.info(f"Writing data to {input_artifact_path}.")
         art.write('cause.latent_tuberculosis_infection.prevalence', p_ltbi)
         art.write('cause.latent_tuberculosis_infection.excess_mortality', f_ltbi)
         art.write('cause.all_causes.cause_specific_mortality_rate', csmr_all)

--- a/src/vivarium_csu_ltbi/data/ltbi_incidence_scripts.py
+++ b/src/vivarium_csu_ltbi/data/ltbi_incidence_scripts.py
@@ -44,7 +44,6 @@ def collect_ltbi_incidence(country):
     data = []
     for f in intermediate_output_path.iterdir():
         data.append(pd.read_hdf(f))
-        f.unlink()
     data = pd.concat(data, axis=0).reset_index()
     output_artifact_path = get_output_artifact_path(country)
     logger.info(f"Writing results to {output_artifact_path}.")


### PR DESCRIPTION
Wipe results before starting a new run. This is a good idea when a cluster workflow of overwriting data is concerned. Stale data is too easy to leave around.

I also changed a bit of logging, now that I have worked with this a bit.