### PR TITLE
Feature/update artifact risk exposure

### DIFF
--- a/src/vivarium_csu_ltbi/components/names.py
+++ b/src/vivarium_csu_ltbi/components/names.py
@@ -1,6 +1,10 @@
 # disease name
 TUBERCULOSIS_AND_HIV = 'tuberculosis_and_hiv'
 
+# risk names
+HOUSEHOLD_TUBERCULOSIS = 'household_tuberculosis'
+RISK_DISTRIBUTION_TYPE = 'dichotomous'
+
 
 #  state names
 ACTIVETB_POSITIVE_HIV = 'activetb_positive_hiv'

--- a/src/vivarium_csu_ltbi/tools/artifact.py
+++ b/src/vivarium_csu_ltbi/tools/artifact.py
@@ -43,7 +43,7 @@ def build_cache():
         logger.info(f"Entity found for id={id}: {entity.name}")
         for loc in LOCATIONS:
             logger.info(f"Pulling for {loc}")
-            vivarium_inputs.get_measure(entity, 'incidence', loc)
+            vivarium_inputs.get_measure(entity, 'incidence_rate', loc)
 
     # Remission
     location_ids = gbd.get_location_ids()

--- a/src/vivarium_csu_ltbi/tools/artifact.py
+++ b/src/vivarium_csu_ltbi/tools/artifact.py
@@ -33,7 +33,7 @@ def build_cache():
         logger.info(f"Entity found for id={id}: {entity.name}")
         for loc in LOCATIONS:
             logger.info(f"Pulling for {loc}")
-            vivarium_inputs.get_measure(entity, 'cause_specific_mortality', loc)
+            vivarium_inputs.get_measure(entity, 'cause_specific_mortality_rate', loc)
 
     # Incidence
     # NOTE: ID 954 fails for all countries -- no non-zero data!

--- a/src/vivarium_csu_ltbi/tools/build_ltbi_artifact.py
+++ b/src/vivarium_csu_ltbi/tools/build_ltbi_artifact.py
@@ -1,8 +1,9 @@
 import click
 from loguru import logger
+
 from vivarium.framework.utilities import handle_exceptions
 
-from . import builder
+from vivarium_csu_ltbi.tools import builder
 
 PROJECT_NAME = 'vivarium_csu_ltbi'
 
@@ -10,7 +11,7 @@ PROJECT_NAME = 'vivarium_csu_ltbi'
 @click.command()
 @click.option('-l', '--location',
               required=True,
-              help=('The location for which to build an artifact'))
+              help='The location for which to build an artifact')
 @click.option('-o', '--output-dir',
               default=f'/share/costeffectiveness/artifacts/{PROJECT_NAME}/',
               show_default=True,

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -94,6 +94,7 @@ class DataRepo:
         ui_ub = 2.98719309
         std = (ui_ub - ui_lb) / (2 * 1.96)
 
+        np.random.seed(12221990)
         draws = np.random.normal(mean, std, 1000)
 
         demog = get_demographic_dimensions(loc)

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -37,7 +37,7 @@ class DataRepo:
 
     @staticmethod
     def get_and_package_dismod_ltbi_incidence(loc):
-        datafile = DEFAULT_PATH / 'ltbi_incidence' / 'knot10' / f'{loc.replace(" ", "_").lower()}.hdf'
+        datafile = DEFAULT_PATH / 'ltbi_incidence' / f'{loc.replace(" ", "_").lower()}.hdf'
         if datafile.exists():
             store = pd.HDFStore(datafile)
             data = store.get('/cause/latent_tuberculosis_infection/incidence')

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -135,12 +135,14 @@ def write_metadata(artifact, location):
 
 
 def write_exposure_data(art, data):
+    logger.info('In write_exposure_data...')
     # distribution type key
     art.write(f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.distribution', RISK_DISTRIBUTION_TYPE)
     art.write(f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.exposure', data.exposure_hhtb)
 
 
 def write_risk_data(art, data):
+    logger.info('In write_risk_data...')
     art.write(f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.relative_risk', data.risk_hhtb)
 
 
@@ -316,6 +318,7 @@ def build_ltbi_artifact(loc, output_dir=None):
     compute_transition_rates(art, data)
 
     write_exposure_data(art, data)
+    write_risk_data(art, data)
 
     logger.info('!!! Done !!!')
 

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -154,25 +154,6 @@ def write_metadata(artifact, location):
     write(artifact, key, load(f'cause.hiv_aids.restrictions'))
 
 
-def write_exposure_risk_data(art, data):
-    logger.info('In write_exposure_risk_data...')
-    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.distribution', RISK_DISTRIBUTION_TYPE)
-    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.exposure', data.exposure_hhtb)
-
-    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.relative_risk', data.risk_hhtb)
-
-    # build paf data
-    ridx = data.risk_hhtb.index.copy()
-    ridx = ridx.droplevel('parameter')
-    one_minus_exp = 1.0 - data.exposure_hhtb.values
-    num = ((data.risk_hhtb.values * data.exposure_hhtb.values) + one_minus_exp) - 1
-    den = (data.risk_hhtb.values * data.exposure_hhtb.values) + one_minus_exp
-    paf = num / den
-    df_paf = pd.DataFrame(paf, ridx, [f'draw_{i}' for i in range(0, 1000)])
-
-    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.population_attributable_fraction', df_paf)
-
-
 def write_demographic_data(artifact, location, data):
     logger.info('Writing demographic data...')
     load = get_load(location)

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -109,6 +109,10 @@ def write_metadata(artifact, location):
     write(artifact, key, load(f'cause.hiv_aids.restrictions'))
 
 
+def write_exposure_type_key(art):
+    art.write( f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.distribution', RISK_DISTRIBUTION_TYPE)
+
+
 def write_demographic_data(artifact, location, data):
     logger.info('Writing demographic data...')
     load = get_load(location)
@@ -274,10 +278,14 @@ def build_ltbi_artifact(loc, output_dir=None):
     art = create_new_artifact(out_path, loc)
     write_demographic_data(art, loc, data)
     write_metadata(art, loc)
+
     compute_prevalence(art, data)
     compute_excess_mortality(art, data)
     compute_disability_weight(art, data)
     compute_transition_rates(art, data)
+
+    write_exposure_type_key(art)
+
     logger.info('!!! Done !!!')
 
 

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -9,7 +9,8 @@ from vivarium_inputs.data_artifact.utilities import split_interval
 from vivarium_inputs.data_artifact.loaders import loader
 from vivarium_inputs import get_measure, utilities, globals, utility_data
 from vivarium_gbd_access import gbd
-from ..components.names import *
+
+from vivarium_csu_ltbi.components.names import *
 
 
 PROJ_NAME = 'vivarium_csu_ltbi'
@@ -34,7 +35,8 @@ class DataRepo:
     def get_filled_with(self, fill_value):
         return pd.DataFrame().reindex_like(self._df_template.copy(deep='all')).fillna(fill_value)
 
-    def get_and_package_dismod_ltbi_incidence(self, loc):
+    @staticmethod
+    def get_and_package_dismod_ltbi_incidence(loc):
         datafile = DEFAULT_PATH / 'ltbi_incidence' / 'knot10' / f'{loc.replace(" ", "_").lower()}.hdf'
         if datafile.exists():
             store = pd.HDFStore(datafile)
@@ -49,12 +51,14 @@ class DataRepo:
         else:
             raise ValueError(f'Error: dismod data "{datafile}" is missing.')
 
-    def get_hh_tuberculosis_exposure(self, loc):
+    @staticmethod
+    def get_hh_tuberculosis_exposure(loc):
         KNOWN_VALUE = 0.5
         df = get_measure(risk_factors.occupational_exposure_to_asbestos, 'exposure', loc)
         return set_to_known_value(df, KNOWN_VALUE)
 
-    def get_hh_tuberculosis_risk(self, loc):
+    @staticmethod
+    def get_hh_tuberculosis_risk(loc):
         df = get_measure(risk_factors.diet_low_in_calcium, 'relative_risk', loc)
         df_flat = df.reset_index()
 
@@ -81,7 +85,6 @@ class DataRepo:
         data[odd] = data[odd] * 3
 
         return pd.DataFrame(data, df_dup.index, [f'draw_{i}' for i in range(0, 1000)])
-
 
     def pull_data(self, loc):
         logger.info('Pulling cause_specific_mortality data')
@@ -138,8 +141,8 @@ class DataRepo:
         self.df_zero = self.get_filled_with(0.0)
 
 
-def entity_from_id(id):
-    return [c for c in causes if c.gbd_id == id][0]
+def entity_from_id(entity_id):
+    return [c for c in causes if c.gbd_id == entity_id][0]
 
 
 def get_load(location):
@@ -345,11 +348,3 @@ def build_ltbi_artifact(loc, output_dir=None):
     write_exposure_risk_data(art, data)
 
     logger.info('!!! Done !!!')
-
-
-
-
-
-
-
-

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -116,6 +116,8 @@ class DataRepo:
         hiv_negative['affected_entity'] = "susceptible_tb_susceptible_hiv_to_ltbi_susceptible_hiv"
 
         complete = pd.concat([hiv_negative, hiv_positive], axis=0)
+        complete = complete.set_index(['location', 'parameter', 'sex', 'age_start', 'age_end',
+                                       'affected_entity', 'affected_measure'])
         rr = utilities.sort_hierarchical_data(complete)
 
         return rr

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -1,8 +1,6 @@
-import numpy as np
 from pathlib import Path
 from loguru import logger
 import pandas as pd
-import numpy as np
 
 from gbd_mapping import causes, risk_factors
 from vivarium.framework.artifact import EntityKey, get_location_term, Artifact
@@ -363,17 +361,6 @@ def build_ltbi_artifact(loc, output_dir=None):
     compute_excess_mortality(art, data)
     compute_disability_weight(art, data)
     compute_transition_rates(art, data)
-<<<<<<< HEAD
-=======
-    write_exposure_risk_data(art, data)
-    logger.info('!!! Done !!!')
-
-
-
-
-
-
->>>>>>> master
 
     write_exposure_risk_data(art, data)
 

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -137,13 +137,13 @@ def write_metadata(artifact, location):
 def write_exposure_data(art, data):
     logger.info('In write_exposure_data...')
     # distribution type key
-    art.write(f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.distribution', RISK_DISTRIBUTION_TYPE)
-    art.write(f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.exposure', data.exposure_hhtb)
+    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.distribution', RISK_DISTRIBUTION_TYPE)
+    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.exposure', data.exposure_hhtb)
 
 
 def write_risk_data(art, data):
     logger.info('In write_risk_data...')
-    art.write(f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.relative_risk', data.risk_hhtb)
+    write(art, f'risk_factor.{HOUSEHOLD_TUBERCULOSIS}.relative_risk', data.risk_hhtb)
 
 
 def write_demographic_data(artifact, location, data):

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from loguru import logger
 import pandas as pd
+import numpy as np
 
 from gbd_mapping import causes, risk_factors
 from vivarium.framework.artifact import EntityKey, get_location_term, Artifact
 from vivarium_inputs.data_artifact.utilities import split_interval
 from vivarium_inputs.data_artifact.loaders import loader
-from vivarium_inputs import get_measure, utilities, globals, utility_data
+from vivarium_inputs import get_measure, utilities, globals, utility_data, get_demographic_dimensions
 from vivarium_gbd_access import gbd
 
 from vivarium_csu_ltbi.components.names import *
@@ -52,38 +53,62 @@ class DataRepo:
 
     @staticmethod
     def get_hh_tuberculosis_exposure(loc):
-        df = get_measure(risk_factors.vitamin_a_deficiency, 'exposure', loc)
-        df.loc[df.index.get_level_values(level='parameter') == 'cat1'] = 0.1
-        df.loc[df.index.get_level_values(level='parameter') == 'cat2'] = 0.9
 
-        df = split_interval(df, interval_column='age', split_column_prefix='age')
-        df = split_interval(df, interval_column='year', split_column_prefix='year')
-        return df
+        df = pd.read_hdf(f'/share/costeffectiveness/artifacts/vivarium_csu_ltbi/household_tb/{loc.replace(" ", "_").lower()}.hdf')
+        df = df.rename(columns={'age_group_start': 'age_start', 'age_group_end': 'age_end', 'pr_actb_in_hh': 'value'})
+
+        cat1 = df.copy()
+        cat1['parameter'] = 'cat1'
+
+        cat2 = df.copy()
+        cat2['parameter'] = 'cat2'
+        cat1['value'] = 1 - cat2['value']
+
+        complete = pd.concat([cat1, cat2], axis=0).reset_index(drop=True)
+        complete = complete.set_index(
+            ['location', 'parameter', 'sex', 'age_start', 'year_start', 'age_end', 'year_end'])
+        complete['draw'] = complete['draw'].apply(lambda x: f'draw_{x}')
+
+        wide = pd.pivot_table(complete,
+                              index=['location', 'parameter', 'sex', 'age_start', 'year_start', 'age_end', 'year_end'],
+                              columns=['draw'], values=['value'])
+        wide.columns = wide.columns.get_level_values('draw')
+        wide = utilities.sort_hierarchical_data(wide)
+
+        return wide
 
     @staticmethod
     def get_hh_tuberculosis_risk(loc):
-        df = get_measure(risk_factors.vitamin_a_deficiency, 'relative_risk', loc)
-        df = split_interval(df, interval_column='age', split_column_prefix='age')
-        df = split_interval(df, interval_column='year', split_column_prefix='year')
+        # From Yaqi via Abie. Preliminary, not age- or sex-specific.
+        mean = 2.108823418
+        ui_lb = 1.488734097
+        ui_ub = 2.98719309
+        std = (ui_ub - ui_lb) / (2 * 1.96)
 
-        df = df.reset_index()
-        df = df.loc[df.affected_entity == 'diarrheal_diseases']
+        draws = np.random.normal(mean, std, 1000)
 
-        df.affected_entity = "susceptible_tb_positive_hiv_to_ltbi_positive_hiv"
-        df.affected_measure = 'transition_rate'
+        demog = get_demographic_dimensions('India')
+        demog = split_interval(demog, interval_column='age', split_column_prefix='age').reset_index()
+        demog = demog.drop(columns=['year'])
+        demog['affected_entity'] = "susceptible_tb_positive_hiv_to_ltbi_positive_hiv"
+        demog['affected_measure'] = 'transition_rate'
 
-        df.loc[df.parameter == 'cat2', [c for c in df.columns if 'draw' in c]] = 1.0
-        df.loc[df.parameter == 'cat1', [c for c in df.columns if 'draw' in c]] = 3.0
+        cat1 = demog.copy()
+        cat1['parameter'] = 'cat1'
+        cat1 = pd.concat([cat1, pd.DataFrame(data={f'draw_{i}': [1.0] * len(cat1.index) for i in range(1000)})], axis=1)
 
-        hiv_positive = df.copy()
-        hiv_negative = df.copy()
+        cat2 = demog.copy()
+        cat2['parameter'] = 'cat2'
+        cat2 = pd.concat([cat2, pd.DataFrame(data={f'draw_{i}': [draws[i]] * len(cat2.index) for i in range(1000)})],
+                         axis=1)
 
-        hiv_negative.affected_entity = "susceptible_tb_susceptible_hiv_to_ltbi_susceptible_hiv"
-        hiv_negative.loc[hiv_negative.parameter == 'cat1', [c for c in hiv_negative.columns if 'draw' in c]] = 2.0
+        hiv_positive = pd.concat([cat1, cat2], axis=0, ignore_index=True)
+        hiv_negative = hiv_positive.copy()
+        hiv_negative['affected_entity'] = "susceptible_tb_susceptible_hiv_to_ltbi_susceptible_hiv"
 
-        data = pd.concat([hiv_positive, hiv_negative], ignore_index=True)
-        data = data.set_index([c for c in data.columns if 'draw' not in c])
-        return data
+        complete = pd.concat([hiv_negative, hiv_positive], axis=0)
+        
+        return complete
 
     def pull_data(self, loc):
         logger.info('Pulling cause_specific_mortality data')

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -58,8 +58,8 @@ class DataRepo:
         # set the 2 states
         idx_odd = df_dup.index.values % 2 == 1
         idx_even = df_dup.index.values % 2 == 0
-        df_dup.loc[idx_odd, "affected_entity"] = "susceptible_tb_positive_hiv"
-        df_dup.loc[idx_even, "affected_entity"] = "susceptible_tb_susceptible_hiv"
+        df_dup.loc[idx_odd, "affected_entity"] = "susceptible_tb_susceptible_hiv_to_ltbi_susceptible_hiv"
+        df_dup.loc[idx_even, "affected_entity"] = "susceptible_tb_positive_hiv_to_ltbi_positive_hiv"
 
         # reset the index
         df_dup = df_dup.set_index(['location', 'sex', 'age', 'year', 'affected_entity', 'affected_measure', 'parameter'])
@@ -236,6 +236,15 @@ def compute_disability_weight(art, data):
     write(art, f'sequela.{ACTIVETB_POSITIVE_HIV}.disability_weight', total_disability_weight)
 
 
+def compute_paf(art, data):
+    # RR: relative risk
+    # p: exposure
+    # RR * (p - 1) / (RR * (p - 1) + 1)
+    p_minus_one = data.exposure_hhtb - 1
+    paf = data.risk_hhtb * p_minus_one / data.risk_hhtb * p_minus_one + 1
+    write(art, f'etiology.{HOUSEHOLD_TUBERCULOSIS}.population_attributable_fraction', paf)
+
+
 def load_em_from_meid(meid, location):
     location_id = utility_data.get_location_id(location)
     data = gbd.get_modelable_entity_draws(meid, location_id)
@@ -319,6 +328,7 @@ def build_ltbi_artifact(loc, output_dir=None):
 
     write_exposure_data(art, data)
     write_risk_data(art, data)
+    compute_paf(art, data)
 
     logger.info('!!! Done !!!')
 

--- a/src/vivarium_csu_ltbi/tools/builder.py
+++ b/src/vivarium_csu_ltbi/tools/builder.py
@@ -62,7 +62,7 @@ class DataRepo:
         df_dup.loc[idx_even, "affected_entity"] = "susceptible_tb_susceptible_hiv"
 
         # reset the index
-        df_dup.set_index(['location', 'sex', 'age', 'year', 'affected_entity', 'affected_measure', 'parameter'])
+        df_dup = df_dup.set_index(['location', 'sex', 'age', 'year', 'affected_entity', 'affected_measure', 'parameter'])
         return df_dup
 
     def pull_data(self, loc):


### PR DESCRIPTION
Update the risk exposure, relative risk, and population attributable fraction calculations in the artifact builder script as well as some style edits.

Also updates the measure names in the cache builder that changed due to the updated vivarium dependencies