### PR TITLE
wip: add better disease state correlate with hhtb

### DIFF
--- a/src/vivarium_csu_ltbi/components/disease.py
+++ b/src/vivarium_csu_ltbi/components/disease.py
@@ -45,13 +45,13 @@ class CorrelatedHHTBBetterDiseaseState(BetterDiseaseState):
         self.prevalence_pipeline = builder.value.register_value_producer(
             f'{self.state_id}.prevalence',
             source=self.prevalence,
-            requires_columns=[]
+            requires_columns=['year', 'age', 'sex']
         )
 
         self.birth_prevalence_pipeline = builder.value.register_value_producer(
             f'{self.state_id}.birth_prevalence',
             source=self.birth_prevalence,
-            requires_columns=[]
+            requires_columns=['year', 'sex']
         )
 
 


### PR DESCRIPTION
This introduces a new disease state that exposes prevalence and birth prevalence as pipelines sourced from lookup tables. The birth prevalence data is sourced from the youngest age group in prevalence.