### PR TITLE
swap prev/birth prev tables for pipelines and refactor

### DIFF
--- a/src/vivarium_csu_ltbi/components/disease.py
+++ b/src/vivarium_csu_ltbi/components/disease.py
@@ -19,6 +19,37 @@ class BetterDiseaseModel(DiseaseModel):
 
 
 class BetterDiseaseState(DiseaseState):
+
+    def setup(self, builder):
+        super().setup(builder)
+
+        # FIXME: Our goal is to use a pipeline to source prevalence and birth
+        #        prevalence rather than a lookup table because the pipeline
+        #        will allow us to intervene on those values to induce
+        #        correlation with household TB exposure. The bits that rely only
+        #        prevalence and birth prevalence to initialize population are
+        #        nestled in complex functions inside disease state. But, lookup
+        #        tables and pipelines have the same interface, so we can do a
+        #        bait and switch. We will rename the lookup tables and then
+        #        define attributes with the expected names that are pipelines
+        #        sourcing the lookup tables.
+
+        # re-assign lookup tables
+        self._prevalence = self.prevalence
+        self._birth_prevalence = self.birth_prevalence
+
+        # Overwrite the lookup table attributes with pipelines
+        self.prevalence = builder.value.register_value_producer(
+            f'{self.state_id}.prevalence',
+            source=self._prevalence,
+            requires_columns=['year', 'age', 'sex']
+        )
+        self.birth_prevalence = builder.value.register_value_producer(
+            f'{self.state_id}.birth_prevalence',
+            source=self._birth_prevalence,
+            requires_columns=['year', 'sex']
+        )
+
     def add_transition(self, output, source_data_type=None, get_data_functions=None, **kwargs):
         if get_data_functions == None:
             get_data_functions = {'transition_rate': lambda cause, builder: builder.data.load(
@@ -30,29 +61,6 @@ class BetterDiseaseState(DiseaseState):
     def metrics(self, index, metrics):
         """Suppress unnecessary columns."""
         return metrics
-
-
-class CorrelatedHHTBBetterDiseaseState(BetterDiseaseState):
-    """BetterDiseaseState but includes pipelines for prevalence and birth
-    prevalence. These pipelines will be modified to alter the effective
-    prevalence based on household tb exposure.
-
-    This disease state presupposed birth prevalence data.
-    """
-    def setup(self, builder):
-        super().setup(builder)
-
-        self.prevalence_pipeline = builder.value.register_value_producer(
-            f'{self.state_id}.prevalence',
-            source=self.prevalence,
-            requires_columns=['year', 'age', 'sex']
-        )
-
-        self.birth_prevalence_pipeline = builder.value.register_value_producer(
-            f'{self.state_id}.birth_prevalence',
-            source=self.birth_prevalence,
-            requires_columns=['year', 'sex']
-        )
 
 
 class BetterSusceptibleState(SusceptibleState):
@@ -104,8 +112,8 @@ def wrapped_birth_prevalence_getter(id):
     }
 
 
-def get_disease_state(id, state_class, getters):
-    ds = state_class(id, cause_type='sequela', get_data_functions=getters)
+def get_disease_state(id):
+    ds = BetterDiseaseState(id, cause_type='sequela', get_data_functions=wrapped_builder_getter(id))
     ds.allow_self_transitions()
     return ds
 
@@ -116,22 +124,17 @@ def TuberculosisAndHIV():
     susceptible.allow_self_transitions()
 
     # the 'disease 'states
-    ltbi_susceptible_hiv = get_disease_state(ltbi_globals.LTBI_SUSCEPTIBLE_HIV, CorrelatedHHTBBetterDiseaseState,
-                                             {**wrapped_builder_getter(ltbi_globals.LTBI_SUSCEPTIBLE_HIV),
-                                              **wrapped_birth_prevalence_getter(ltbi_globals.LTBI_SUSCEPTIBLE_HIV)})
+    ltbi_susceptible_hiv = get_disease_state(ltbi_globals.LTBI_SUSCEPTIBLE_HIV)
+    # ltbi_susceptible_hiv._get_data_functions.update(wrapped_birth_prevalence_getter(ltbi_globals.LTBI_SUSCEPTIBLE_HIV))
 
-    activetb_susceptible_hiv = get_disease_state(ltbi_globals.ACTIVETB_SUSCEPTIBLE_HIV, BetterDiseaseState,
-                                                 wrapped_builder_getter(ltbi_globals.ACTIVETB_SUSCEPTIBLE_HIV))
+    activetb_susceptible_hiv = get_disease_state(ltbi_globals.ACTIVETB_SUSCEPTIBLE_HIV)
 
-    susceptible_tb_positive_hiv = get_disease_state(ltbi_globals.SUSCEPTIBLE_TB_POSITIVE_HIV, BetterDiseaseState,
-                                                    wrapped_builder_getter(ltbi_globals.SUSCEPTIBLE_TB_POSITIVE_HIV))
+    susceptible_tb_positive_hiv = get_disease_state(ltbi_globals.SUSCEPTIBLE_TB_POSITIVE_HIV)
 
-    ltbi_positive_hiv = get_disease_state(ltbi_globals.LTBI_POSITIVE_HIV, CorrelatedHHTBBetterDiseaseState,
-                                          {**wrapped_builder_getter(ltbi_globals.LTBI_POSITIVE_HIV),
-                                           **wrapped_birth_prevalence_getter(ltbi_globals.LTBI_POSITIVE_HIV)})
+    ltbi_positive_hiv = get_disease_state(ltbi_globals.LTBI_POSITIVE_HIV)
+    # ltbi_positive_hiv._get_data_functions.update(wrapped_birth_prevalence_getter(ltbi_globals.LTBI_POSITIVE_HIV))
 
-    activetb_positive_hiv = get_disease_state(ltbi_globals.ACTIVETB_POSITIVE_HIV, BetterDiseaseState,
-                                              wrapped_builder_getter(ltbi_globals.ACTIVETB_POSITIVE_HIV))
+    activetb_positive_hiv = get_disease_state(ltbi_globals.ACTIVETB_POSITIVE_HIV)
 
     # the transitions
     susceptible.add_transition(ltbi_susceptible_hiv)

--- a/src/vivarium_csu_ltbi/components/disease.py
+++ b/src/vivarium_csu_ltbi/components/disease.py
@@ -125,14 +125,14 @@ def TuberculosisAndHIV():
 
     # the 'disease 'states
     ltbi_susceptible_hiv = get_disease_state(ltbi_globals.LTBI_SUSCEPTIBLE_HIV)
-    # ltbi_susceptible_hiv._get_data_functions.update(wrapped_birth_prevalence_getter(ltbi_globals.LTBI_SUSCEPTIBLE_HIV))
+    ltbi_susceptible_hiv._get_data_functions.update(wrapped_birth_prevalence_getter(ltbi_globals.LTBI_SUSCEPTIBLE_HIV))
 
     activetb_susceptible_hiv = get_disease_state(ltbi_globals.ACTIVETB_SUSCEPTIBLE_HIV)
 
     susceptible_tb_positive_hiv = get_disease_state(ltbi_globals.SUSCEPTIBLE_TB_POSITIVE_HIV)
 
     ltbi_positive_hiv = get_disease_state(ltbi_globals.LTBI_POSITIVE_HIV)
-    # ltbi_positive_hiv._get_data_functions.update(wrapped_birth_prevalence_getter(ltbi_globals.LTBI_POSITIVE_HIV))
+    ltbi_positive_hiv._get_data_functions.update(wrapped_birth_prevalence_getter(ltbi_globals.LTBI_POSITIVE_HIV))
 
     activetb_positive_hiv = get_disease_state(ltbi_globals.ACTIVETB_POSITIVE_HIV)
 


### PR DESCRIPTION
this is a small refactor -- all disease states now have pipelines -- as well as officially swapping lookup tables out for pipelines for prevalence and birth prevalence. This is simply done using a bait-and-switch with the attribute names expected by the simulant initialization code in the disease model. It works because the api is idential -- a callable that expects a population index. 